### PR TITLE
Fix the compile error.

### DIFF
--- a/Assets/Tests/EditMode/AssemblyDefinition.asmdef
+++ b/Assets/Tests/EditMode/AssemblyDefinition.asmdef
@@ -3,7 +3,8 @@
     "references": [
         "umm@cafu_point",
         "umm@extra_unirx",
-        "umm@cafu_core"
+        "umm@cafu_core",
+        "umm@cafu_kvs"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"


### PR DESCRIPTION
Fix for the following error on performing tests on the `EditMode`.

```
Assets/Tests/EditMode/Scripts/Domain/UseCase/PointUseCaseTest.cs(16,55): error CS0012: The type `CAFU.KeyValueStore.Domain.Repository.IKeyValueRepository' is defined in an assembly that is not referenced. Consider adding a reference to assembly `umm@cafu_kvs, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'
```